### PR TITLE
Adding support to debian os family and to modcluster 1.3.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,14 @@
 class modcluster(
-  $port = '6666',
-  $listen_ip_address = '127.0.0.1',
-  $allowed_network = '127.0.0.1',
-  $balancer_name = 'mybalancer',
-  $manager_allowed_network = '127.0.0.1',
-  $download_url = undef,
-) {
+  $port = $modcluster::params::port,
+  $listen_ip_address = $modcluster::params::port,
+  $allowed_network = $modcluster::params::allowed_network,
+  $balancer_name = $modcluster::params::balancer_name,
+  $manager_allowed_network = $modcluster::params::manager_allowed_network,
+  $download_url = $modcluster::params::download_url,
+  $modules_dir = $modcluster::params::modules_dir,
+  $mem_manager_file = $modcluster::params::mem_manager_file,
+  $version = $modcluster::params::version
+) inherits modcluster::params {
 
   $file_name = inline_template('<%= require \'uri\'; File.basename(URI::parse(@download_url).path) %>')
 
@@ -19,14 +22,14 @@ class modcluster(
 
   exec { 'Extract modcluster':
     command     => "tar -xzf /opt/${file_name}",
-    cwd         => '/etc/httpd/modules',
-    creates     => "/etc/httpd/modules/mod_proxy_cluster.so",
+    cwd         => "${modules_dir}",
+    creates     => "${modules_dir}/mod_proxy_cluster.so",
     group       => 'root',
     user        => 'root',
     path        => ['/usr/bin', '/usr/sbin', '/bin', '/sbin']
   }
 
-  file { '/etc/httpd/conf.d/modcluster.conf':
+  file { "${modcluster::params::conf_file}":
     ensure  => file,
     owner   => 'root',
     group   => 'root',
@@ -34,5 +37,27 @@ class modcluster(
     mode    => '0755',
     require => Exec['Extract modcluster']
   }
+
+  if $::osfamily == 'Debian' {
+    file { "${modcluster::params::load_module_file}":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      content => template('modcluster/modcluster.load.erb'),
+      mode    => '0755',
+      require => File["${modcluster::params::conf_file}"]
+}
+
+    exec { 'Enable modcluster module':
+      command     => "a2enmod modcluster",
+      cwd         => '/etc/apache2',
+      creates     => "/etc/apache2/mods-enabled/modcluster.load",
+      group       => 'root',
+      user        => 'root',
+      path        => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
+      require     => File["${modcluster::params::load_module_file}"],
+    }
+  }
+
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,34 @@
+class modcluster::params {
+
+  $port = '6666'
+  $listen_ip_address = '127.0.0.1'
+  $allowed_network = '127.0.0.1'
+  $balancer_name = 'mybalancer'
+  $manager_allowed_network = '127.0.0.1'
+  $download_url = undef
+  $version = '1.2.6'
+
+  $modules_dir = $::osfamily? {
+    'Debian' => '/usr/lib/apache2/modules',
+    'RedHat' => '/etc/httpd/modules',
+    default => '/etc/httpd/modules'
+  }
+
+  $conf_file = $::osfamily? {
+    'Debian' => '/etc/apache2/mods-available/modcluster.conf',
+    'RedHat' => '/etc/httpd/conf.d/modcluster.conf',
+    default => '/etc/httpd/conf.d/modcluster.conf'
+  }
+
+  $load_module_file = $::osfamily? {
+    'Debian' => '/etc/apache2/mods-available/modcluster.load',
+    default => undef,
+  }
+
+  $mem_manager_file = $::osfamily? {
+    'Debian' => '/var/cache/apache2/manager.node',
+    'RedHat' => '/etc/httpd/logs/manager.node',
+    default => '/etc/httpd/logs/manager.node'
+  }
+
+}

--- a/templates/modcluster.conf.erb
+++ b/templates/modcluster.conf.erb
@@ -1,4 +1,6 @@
 LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module_http modules/mod_proxy_http.so
+LoadModule proxy_module_ajp modules/mod_proxy_ajp.so
 LoadModule slotmem_module modules/mod_slotmem.so
 LoadModule manager_module modules/mod_manager.so
 LoadModule proxy_cluster_module modules/mod_proxy_cluster.so

--- a/templates/modcluster.conf.erb
+++ b/templates/modcluster.conf.erb
@@ -1,6 +1,4 @@
 LoadModule proxy_module modules/mod_proxy.so
-LoadModule proxy_http_module modules/mod_proxy_http.so
-LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule slotmem_module modules/mod_slotmem.so
 LoadModule manager_module modules/mod_manager.so
 LoadModule proxy_cluster_module modules/mod_proxy_cluster.so

--- a/templates/modcluster.conf.erb
+++ b/templates/modcluster.conf.erb
@@ -1,6 +1,6 @@
 LoadModule proxy_module modules/mod_proxy.so
-LoadModule proxy_module_http modules/mod_proxy_http.so
-LoadModule proxy_module_ajp modules/mod_proxy_ajp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule slotmem_module modules/mod_slotmem.so
 LoadModule manager_module modules/mod_manager.so
 LoadModule proxy_cluster_module modules/mod_proxy_cluster.so

--- a/templates/modcluster.conf.erb
+++ b/templates/modcluster.conf.erb
@@ -1,8 +1,8 @@
-LoadModule proxy_module modules/mod_proxy.so
-LoadModule slotmem_module modules/mod_slotmem.so
-LoadModule manager_module modules/mod_manager.so
-LoadModule proxy_cluster_module modules/mod_proxy_cluster.so
-LoadModule advertise_module modules/mod_advertise.so
+<% if scope.lookupvar("modcluster::params::load_module_file") == :undef %>
+<%= scope.function_template('modcluster.load.erb') %>
+<% end %>
+
+MemManagerFile <%= @mem_manager_file %>
 
 Listen <%= @listen_ip_address %>:<%= @port %>
 <VirtualHost <%= @listen_ip_address %>:<%= @port %>>

--- a/templates/modcluster.load.erb
+++ b/templates/modcluster.load.erb
@@ -1,0 +1,9 @@
+LoadModule proxy_module <%= @modules_dir %>/mod_proxy.so
+<% if @version =~ /1\.[0-2]\..+/ %>
+LoadModule slotmem_module <%= @modules_dir %>/mod_slotmem.so
+<% else %>
+LoadModule cluster_slotmem_module <%= @modules_dir %>/mod_cluster_slotmem.so
+<% end %>
+LoadModule manager_module <%= @modules_dir %>/mod_manager.so
+LoadModule proxy_cluster_module <%= @modules_dir %>/mod_proxy_cluster.so
+LoadModule advertise_module <%= @modules_dir %>/mod_advertise.so


### PR DESCRIPTION
I replaced some hardcoded paths like /etc/httpd/modules, which won't work on debian based distributions. Also, on the latter, there's a separation between load and conf files. The .erb templates now reflect those differences.  A params.pp was added to check differences in parameters depending on os family. Additionally some parameters were included in init.pp if the user needs to customize a path.

Also, in modcluster 1.3.x, the mod_slotmem was changed to mod_cluster_slotmem. A regex was included on the file modcluster.load.erb to check the version and add load the correct module.